### PR TITLE
Testing DB, `npm run test`

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,4 +2,5 @@
 # https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
 # https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser
 
+# See `./docker-compose.yml`
 DATABASE_URL=postgresql://postgres:password@localhost:6001/postgres

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,2 @@
-# SQLite is ready to go out of the box, but you can switch to Postgres
-# by first changing the provider from "sqlite" to "postgres" in the Prisma
-# schema file and by second swapping the DATABASE_URL below.
-DATABASE_URL="file:./db_test.sqlite"
-# DATABASE_URL=postgresql://fmc@localhost:5432/rsv-builder_test
+# See `./docker-compose.yml`
+DATABASE_URL=postgresql://postgres:password@localhost:6002/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,13 @@ services:
     volumes:
       - rsv-data:/var/lib/postgresql/data
     container_name: rsv-builder-db
+  db-test:
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_PASSWORD: password
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    ports:
+      - "6002:5432"
 volumes:
   rsv-data:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "blitz start",
+    "predev": "docker-compose up -d",
     "dev": "NODE_OPTIONS='--inspect' blitz dev",
     "debug": "DEBUG=blitz:* blitz console",
     "build": "blitz build",


### PR DESCRIPTION
I followed https://blitzjs.com/docs/postgres#on-mac.

However, this should work but does not.

The last item is…
> Start your new database and get it to the latest version of your migrations by running docker-compose up -d and blitz prisma migrate dev.


However, the `blitz prisma migrate dev`did not migrate the test db. And there is no "migrate test".

**Goal:**

Be able to run `npm run test` (and see the errors that this will produce … :)