### PR TITLE
Export API: include all subsection geometry types in GeoJSON

### DIFF
--- a/src/routes/api/projects/$slug/index.ts
+++ b/src/routes/api/projects/$slug/index.ts
@@ -1,5 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { featureCollection, lineString } from "@turf/helpers"
+import { featureCollection } from "@turf/helpers"
+import type { Feature } from "geojson"
+import { lineStringToGeoJSON } from "@/src/components/core/components/Map/utils/lineStringToGeoJSON"
+import { polygonToGeoJSON } from "@/src/components/core/components/Map/utils/polygonToGeoJSON"
 import { endpointAuth } from "@/src/server/auth/endpointAuth.server"
 import db from "@/src/server/db.server"
 import { typeSubsectionGeometry } from "@/src/server/subsections/utils/typeSubsectionGeometry"
@@ -55,23 +58,29 @@ export const Route = createFileRoute("/api/projects/$slug/")({
             },
           })
 
-          // TODO: Handle other geometry types
-          const projectFeatures = featureCollection(
-            subsections
-              .map((subsection) => {
-                const { geometry } = typeSubsectionGeometry(subsection)
-                if (geometry.type !== "LineString") return null
+          // Public GeoJSON export: one Feature per geometry part.
+          // LINE → LineString feature(s); MultiLineString → one LineString feature per part.
+          // POLYGON → Polygon feature(s); MultiPolygon → one Polygon feature per part.
+          // Export properties are duplicated on every feature from the same subsection.
+          const features = subsections.flatMap<Feature>((subsection) => {
+            const typedSubsection = typeSubsectionGeometry(subsection)
+            const properties = {
+              subsectionSlug: subsection.slug,
+              projectSlug,
+              operator: subsection.operator?.title,
+              estimatedCompletionDateString: subsection.estimatedCompletionDateString,
+              status: subsection.SubsectionStatus?.title,
+            }
 
-                return lineString(geometry.coordinates, {
-                  subsectionSlug: subsection.slug,
-                  projectSlug,
-                  operator: subsection.operator?.title,
-                  estimatedCompletionDateString: subsection.estimatedCompletionDateString,
-                  status: subsection.SubsectionStatus?.title,
-                })
-              })
-              .filter((feature) => feature !== null),
-          )
+            switch (typedSubsection.type) {
+              case "LINE":
+                return lineStringToGeoJSON(typedSubsection.geometry, properties)
+              case "POLYGON":
+                return polygonToGeoJSON(typedSubsection.geometry, properties)
+            }
+          })
+
+          const projectFeatures = featureCollection(features)
 
           return new Response(JSON.stringify(projectFeatures), {
             headers: corsHeaders,

--- a/tests/project/project-export-api.spec.ts
+++ b/tests/project/project-export-api.spec.ts
@@ -42,7 +42,31 @@ test.describe("Project export API", () => {
     })
     createdSubsectionIds.push(lineSubsection.id)
 
-    // Non-LineString subsection: must be filtered out of the export.
+    // MultiLineString subsection: exported as one LineString feature per part.
+    const multiLineSubsection = await db.subsection.create({
+      data: {
+        projectId: project.id,
+        slug: "s3-multi-line",
+        type: "LINE",
+        geometry: {
+          type: "MultiLineString",
+          coordinates: [
+            [
+              [13.42, 52.5],
+              [13.43, 52.51],
+            ],
+            [
+              [13.44, 52.52],
+              [13.45, 52.53],
+            ],
+          ],
+        },
+      },
+      select: { id: true },
+    })
+    createdSubsectionIds.push(multiLineSubsection.id)
+
+    // Polygon subsection: included in the export alongside LineString subsections.
     const polygonSubsection = await db.subsection.create({
       data: {
         projectId: project.id,
@@ -97,7 +121,7 @@ test.describe("Project export API", () => {
     const payload = (await response.json()) as {
       type: string
       features: Array<{
-        geometry: { type: string; coordinates: number[][] }
+        geometry: { type: string; coordinates: number[][] | number[][][] }
         properties: {
           subsectionSlug: string
           projectSlug: string
@@ -109,11 +133,27 @@ test.describe("Project export API", () => {
     }
 
     expect(payload.type).toBe("FeatureCollection")
-    // Only the LineString subsection is exported; the POLYGON one is filtered out.
-    expect(payload.features).toHaveLength(1)
-    expect(payload.features.every((feature) => feature.geometry.type === "LineString")).toBe(true)
-    expect(payload.features[0]?.properties.subsectionSlug).toBe("s1")
-    expect(payload.features[0]?.properties.projectSlug).toBe(projectSlug)
+    // LineString (1) + MultiLineString parts (2) + Polygon (1)
+    expect(payload.features).toHaveLength(4)
+
+    const lineFeature = payload.features.find(
+      (feature) =>
+        feature.geometry.type === "LineString" && feature.properties.subsectionSlug === "s1",
+    )
+    const multiLineFeatures = payload.features.filter(
+      (feature) =>
+        feature.geometry.type === "LineString" &&
+        feature.properties.subsectionSlug === "s3-multi-line",
+    )
+    const polygonFeature = payload.features.find((feature) => feature.geometry.type === "Polygon")
+
+    expect(lineFeature?.properties.projectSlug).toBe(projectSlug)
+    expect(multiLineFeatures).toHaveLength(2)
+    expect(
+      multiLineFeatures.every((feature) => feature.properties.projectSlug === projectSlug),
+    ).toBe(true)
+    expect(polygonFeature?.properties.subsectionSlug).toBe("s2-polygon")
+    expect(polygonFeature?.properties.projectSlug).toBe(projectSlug)
   })
 
   test("returns 404 when the project does not exist", async ({ request }) => {


### PR DESCRIPTION
- Public project export returns polygon subsections alongside lines
- MultiLineString and MultiPolygon geometries flatten to one feature per part; properties are duplicated on each feature
- E2E coverage for MultiLineString export behavior

Closes https://github.com/FixMyBerlin/private-issues/issues/3439 and unblocks https://github.com/FixMyBerlin/private-issues/issues/2354